### PR TITLE
Update to allow any new Traceur, and use Traceur Runner

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,5 @@
 // https://github.com/shinnn/gulpur
 
 'use strict';
-
-var traceur = require('traceur');
-
-traceur.require.makeDefault(function(filename) {
-  return filename.indexOf('/node_modules') === -1;
-});
-
+require('traceur-runner');
 require('gulp/bin/gulp.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulpur",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "gulp with Traceur gulpfiles",
   "main": "index.js",
   "bin": "./index.js",
@@ -29,8 +29,8 @@
     "node": ">=0.10"
   },
   "preferGlobal": true,
-  "dependencies": {
-    "traceur": "0.0.32"
+  "peerDependencies": {
+    "traceur": ">= 0.0.79 < 1"
   },
   "devDependencies": {
     "jshint-stylish": "^0.1.5",
@@ -39,6 +39,10 @@
     "gulp-jsonlint": "0.0.3",
     "gulp-concat": "^2.2.0",
     "gulp-mocha": "^0.4.1",
-    "gulp-rimraf": "0.0.9"
+    "gulp-rimraf": "0.0.9",
+    "traceur": "0.0.79"
+  },
+  "dependencies": {
+    "traceur-runner": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,20 @@
 {
   "name": "gulpur",
   "version": "0.0.5",
-  "description": "gulp with ES.next",
+  "description": "gulp with Traceur gulpfiles",
   "main": "index.js",
-  "bin": {
-    "gulpur": "./index.js"
-  },
+  "bin": "./index.js",
   "scripts": {
     "test": "node index.js test",
     "prepublish": "npm test"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/shinnn/gulpur.git"
-  },
+  "repository": "shinnn/gulpur",
   "author": {
     "name": "Shinnosuke Watanabe",
     "email": "snnskwtnb@gmail.com",
     "url": "https://github.com/shinnn"
   },
   "license": "MIT",
-  "readmeFilename": "README.md",
-  "bugs": {
-    "url": "https://github.com/shinnn/gulpur/issues"
-  },
-  "homepage": "https://github.com/shinnn/gulpur",
   "keywords": [
     "gulpfriendly",
     "gulp",


### PR DESCRIPTION
For the benefits of Traceur Runner, see [its readme](https://github.com/domenic/traceur-runner). I put it together because I noticed a lot of code similar to your makeDefault trick, but I wanted something more robust.

Also, it'd be pretty cool if you were willing to bump the version to 1.0.0 after releasing :). I like my dependencies to be semver-compatible.

If you perchance have moved on from this project (I noticed the last commit was in April), I'd be happy to help maintain it.
